### PR TITLE
Markdown to HTML Converter

### DIFF
--- a/src/hakimlutfi46-build-a-markdown-to-html-converter/README.md
+++ b/src/hakimlutfi46-build-a-markdown-to-html-converter/README.md
@@ -22,27 +22,35 @@ This converter supports the following Markdown syntax:
 
 This project requires only Python 3. No external libraries need to be installed.
 
-1.  **Clone the Repository**
-    Clone or download the repository containing this project to your local machine.
-
-2.  **Create an Input File**
-    Create a new file with a `.md` extension (e.g., `sample.md`) and write your content using the supported Markdown syntax.
-
-3.  **Run the Converter Script**
-    Open your terminal or command prompt, navigate to the project directory, and execute the following command:
-
+1.  **Single File Conversion**
     ```powershell
-    python md_converter.py <input_file.md> <output_file.html>
+    python md_converter.py .\sample.md -o .\output.html
     ```
 
-    For example:
+    - If `-o` is omitted, the output will be written next to the input as `.html`.
+    - You can set a custom HTML title:
+      ```powershell
+      python md_converter.py .\sample.md -o .\output.html -t "My Doc"
+      ```
 
+2.  **Directory Conversion**
+    Convert all `.md` files in a directory to `.html` files:
     ```powershell
-    python md_converter.py sample.md output.html
+    python md_converter.py .\docs -o .\public\docs
+    ```
+
+    Recurse into subdirectories:
+    ```powershell
+    python md_converter.py .\docs -o .\public\docs -r
+    ```
+
+3.  **Help**
+    ```powershell
+    python md_converter.py -h
     ```
 
 4.  **View the Output**
-    The script will generate a new `output.html` file in the same directory. You can open this file in any web browser to see the final result.
+    Open the generated `.html` files in any web browser.
 
 ## 📝 Example Usage
 

--- a/src/hakimlutfi46-build-a-markdown-to-html-converter/md_converter.py
+++ b/src/hakimlutfi46-build-a-markdown-to-html-converter/md_converter.py
@@ -2,6 +2,9 @@
 import re
 import sys
 import html
+import os
+import argparse
+from pathlib import Path
 
 def markdown_to_html(markdown_text):
     
@@ -54,30 +57,77 @@ def markdown_to_html(markdown_text):
     return '\n\n'.join(html_output)
 
 
+def _write_html_file(output_file_path, html_body, title="Converted Markdown"):
+    with open(output_file_path, 'w', encoding='utf-8') as f:
+        f.write("<!DOCTYPE html>\n<html lang='en'>\n<head>\n")
+        f.write(f"  <meta charset='UTF-8'>\n  <title>{html.escape(title)}</title>\n</head>\n<body>\n")
+        f.write(html_body)
+        f.write("\n</body>\n</html>")
+
+
+def convert_file(input_file_path: Path, output_file_path: Path, title: str = None) -> None:
+    with open(input_file_path, 'r', encoding='utf-8') as f:
+        markdown_content = f.read()
+    html_content = markdown_to_html(markdown_content)
+    page_title = title or input_file_path.stem
+    output_file_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_html_file(output_file_path, html_content, page_title)
+
+
+def convert_directory(input_dir: Path, output_dir: Path, recursive: bool = False) -> int:
+    pattern = "**/*.md" if recursive else "*.md"
+    count = 0
+    for md_path in input_dir.glob(pattern):
+        if md_path.is_dir():
+            continue
+        relative = md_path.relative_to(input_dir)
+        out_html = (output_dir / relative).with_suffix('.html')
+        convert_file(md_path, out_html)
+        count += 1
+    return count
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Convert Markdown (.md) to HTML. Supports single file or entire directory.")
+    parser.add_argument("input", help="Input .md file or a directory containing .md files")
+    parser.add_argument("-o", "--output", help="Output file (for single file input) or output directory (for directory input)")
+    parser.add_argument("-r", "--recursive", action="store_true", help="Recurse into subdirectories when input is a directory")
+    parser.add_argument("-t", "--title", help="HTML <title> for single file conversion (defaults to filename)")
+    return parser
+
+
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python md_converter.py <input_file.md> <output_file.html>")
+    parser = build_parser()
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"Error: Input path '{input_path}' not found.")
         sys.exit(1)
 
-    input_file_path = sys.argv[1]
-    output_file_path = sys.argv[2]
+    if input_path.is_file():
+        if input_path.suffix.lower() != ".md":
+            print("Error: Input file must have a .md extension.")
+            sys.exit(1)
+        if args.output:
+            output_file = Path(args.output)
+            if output_file.is_dir():
+                output_file = output_file / (input_path.stem + ".html")
+        else:
+            output_file = input_path.with_suffix('.html')
 
-    try:
-        with open(input_file_path, 'r', encoding='utf-8') as f:
-            markdown_content = f.read()
-        
-        html_content = markdown_to_html(markdown_content)
+        convert_file(input_path, output_file, title=args.title)
+        print(f"✅ Conversion successful! File saved to: {output_file}")
+        return
 
-        with open(output_file_path, 'w', encoding='utf-8') as f:
-            f.write("<!DOCTYPE html>\n<html lang='en'>\n<head>\n")
-            f.write("  <meta charset='UTF-8'>\n  <title>Converted Markdown</title>\n</head>\n<body>\n")
-            f.write(html_content)
-            f.write("\n</body>\n</html>")
-
-        print(f"✅ Conversion successful! File saved to: {output_file_path}")
-    except FileNotFoundError:
-        print(f"Error: Input file '{input_file_path}' not found.")
-        sys.exit(1)
+    # Directory input
+    output_dir = Path(args.output) if args.output else (input_path / "html_output")
+    converted = convert_directory(input_path, output_dir, recursive=args.recursive)
+    if converted == 0:
+        print("No .md files found to convert.")
+    else:
+        print(f"✅ Converted {converted} file(s). Output directory: {output_dir}")
 
 if __name__ == "__main__":
     main()

--- a/src/venkateeshh-markdown-to-html-convertor/README.html
+++ b/src/venkateeshh-markdown-to-html-convertor/README.html
@@ -1,0 +1,134 @@
+
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>README</title>
+<style>
+
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial; max-width: 760px; margin: 3rem auto; line-height: 1.6; padding: 0 1rem; }
+pre { background:#f6f8fa; padding:1rem; overflow:auto; }
+code { background:#f6f8fa; padding:0.15rem 0.3rem; border-radius:4px; }
+h1,h2,h3,h4 { margin-top:1.4rem; }
+blockquote { color:#555; border-left:4px solid #ddd; padding-left:1rem; margin:1rem 0; }
+ul,ol { margin:0.5rem 0 1rem 1.25rem; }
+
+</style>
+</head>
+<body>
+<main>
+<h1>Markdown to HTML Converter</h1>
+<p>
+A simple Python-based tool to convert Markdown (<code>.md</code>) files into standalone HTML files.
+</p>
+<p>
+This project includes:
+<ul>
+<li>A <strong>built-in lightweight Markdown parser</strong> (supports headings, lists, code blocks, links, bold/italic, blockquotes, etc.).</li>
+<li>An option to use the <strong><code>markdown</code> PyPI package</strong> for full CommonMark + extensions.</li>
+<li>Support for converting <strong>a single file</strong> or <strong>all <code>.md</code> files in a directory</strong>.</li>
+<li>Optional <strong>custom CSS</strong> or a built-in default style.</li>
+</p>
+</ul>
+<hr/>
+<h2>Features</h2>
+<ul>
+<li>Convert <code>.md</code> files to <code>.html</code> with ease.</li>
+<li>Lightweight built-in parser.</li>
+<li>Support for fenced code blocks (```), headings, lists, blockquotes.</li>
+<li>Inline formatting: <strong>bold</strong>, <em>italic</em>, <code>inline code</code>, <a href="#">links</a>.</li>
+<li>Full CommonMark + tables & extensions with <code>--use-lib</code> (requires <code>pip install markdown</code>).</li>
+<li>Automatically generates a standalone HTML page with styles.</li>
+</ul>
+<hr/>
+<h2>Installation</h2>
+<p>
+Clone this repo and navigate into it:
+</p>
+<pre><code>
+git clone https://github.com/yourusername/md2html.git
+cd md2html
+</code></pre>
+<p>
+(Optional) install the <code>markdown</code> package for extended features:
+</p>
+<pre><code>
+pip install markdown
+</code></pre>
+<hr/>
+<h2>Usage</h2>
+<h3>Convert a single file:</h3>
+<pre><code>
+python md2html.py README.md
+</code></pre>
+<h3>Convert with full Markdown library support:</h3>
+<pre><code>
+python md2html.py README.md --use-lib
+</code></pre>
+<h3>Convert all <code>.md</code> files in a directory:</h3>
+<pre><code>
+python md2html.py docs/ --out-dir site/
+</code></pre>
+<h3>Use custom CSS:</h3>
+<pre><code>
+python md2html.py README.md --css styles.css
+</code></pre>
+<hr/>
+<h2>Example</h2>
+<p>
+Given an input file <code>example.md</code>:
+</p>
+<pre><code>
+# Hello World
+
+This is **Markdown** converted to HTML.
+
+- Item 1
+- Item 2
+
+</code></pre>
+<p>
+Run:
+</p>
+<pre><code>
+python md2html.py example.md
+</code></pre>
+<p>
+Output file <code>example.html</code>:
+</p>
+<pre><code>
+&lt;!doctype html&gt;
+&lt;html lang="en"&gt;
+&lt;head&gt;
+  &lt;meta charset="utf-8" /&gt;
+  &lt;title&gt;example&lt;/title&gt;
+  &lt;style&gt; ... default CSS ... &lt;/style&gt;
+&lt;/head&gt;
+&lt;body&gt;
+  &lt;main&gt;
+    &lt;h1&gt;Hello World&lt;/h1&gt;
+    &lt;p&gt;This is &lt;strong&gt;Markdown&lt;/strong&gt; converted to HTML.&lt;/p&gt;
+    &lt;ul&gt;
+      &lt;li&gt;Item 1&lt;/li&gt;
+      &lt;li&gt;Item 2&lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/main&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+</code></pre>
+<hr/>
+<h2>Options</h2>
+<ul>
+<li><code>--out-dir &lt;dir&gt;</code> → specify an output directory.</li>
+<li><code>--use-lib</code> → use the <code>markdown</code> package instead of the built-in parser.</li>
+<li><code>--css &lt;file&gt;</code> → add a custom CSS file.</li>
+</ul>
+<hr/>
+<h2>License</h2>
+<p>
+MIT License © 2025
+</p>
+</main>
+</body>
+</html>

--- a/src/venkateeshh-markdown-to-html-convertor/README.md
+++ b/src/venkateeshh-markdown-to-html-convertor/README.md
@@ -1,0 +1,111 @@
+# Markdown to HTML Converter
+
+A simple Python-based tool to convert Markdown (`.md`) files into standalone HTML files.
+
+This project includes:
+- A **built-in lightweight Markdown parser** (supports headings, lists, code blocks, links, bold/italic, blockquotes, etc.).
+- An option to use the **`markdown` PyPI package** for full CommonMark + extensions.
+- Support for converting **a single file** or **all `.md` files in a directory**.
+- Optional **custom CSS** or a built-in default style.
+
+---
+
+## Features
+- Convert `.md` files to `.html` with ease.
+- Lightweight built-in parser.
+- Support for fenced code blocks (```), headings, lists, blockquotes.
+- Inline formatting: **bold**, *italic*, `inline code`, [links](#).
+- Full CommonMark + tables & extensions with `--use-lib` (requires `pip install markdown`).
+- Automatically generates a standalone HTML page with styles.
+
+---
+
+## Installation
+
+Clone this repo and navigate into it:
+```bash
+git clone https://github.com/yourusername/md2html.git
+cd md2html
+```
+
+(Optional) install the `markdown` package for extended features:
+```bash
+pip install markdown
+```
+
+---
+
+## Usage
+
+### Convert a single file:
+```bash
+python md2html.py README.md
+```
+
+### Convert with full Markdown library support:
+```bash
+python md2html.py README.md --use-lib
+```
+
+### Convert all `.md` files in a directory:
+```bash
+python md2html.py docs/ --out-dir site/
+```
+
+### Use custom CSS:
+```bash
+python md2html.py README.md --css styles.css
+```
+
+---
+
+## Example
+Given an input file `example.md`:
+```markdown
+# Hello World
+
+This is **Markdown** converted to HTML.
+
+- Item 1
+- Item 2
+
+```
+
+Run:
+```bash
+python md2html.py example.md
+```
+
+Output file `example.html`:
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>example</title>
+  <style> ... default CSS ... </style>
+</head>
+<body>
+  <main>
+    <h1>Hello World</h1>
+    <p>This is <strong>Markdown</strong> converted to HTML.</p>
+    <ul>
+      <li>Item 1</li>
+      <li>Item 2</li>
+    </ul>
+  </main>
+</body>
+</html>
+```
+
+---
+
+## Options
+- `--out-dir <dir>` → specify an output directory.
+- `--use-lib` → use the `markdown` package instead of the built-in parser.
+- `--css <file>` → add a custom CSS file.
+
+---
+
+## License
+MIT License © 2025

--- a/src/venkateeshh-markdown-to-html-convertor/app.py
+++ b/src/venkateeshh-markdown-to-html-convertor/app.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""md2html.py
+
+Simple Markdown -> HTML converter.
+
+Features:
+- Two modes: a) simple built-in Markdown parser (covers headings, bold, italics,
+  links, inline code, code blocks, lists, paragraphs) b) full-featured using
+  the `markdown` PyPI package (if you prefer richer output).
+- Convert a single .md file or all .md files in a directory.
+- Optional CSS file to style output or uses a small default style.
+- Generates a standalone .html file with a basic template.
+
+Usage examples:
+
+    # convert single file using built-in parser
+    python md2html.py README.md
+
+    # convert using the markdown package (pip install markdown)
+    python md2html.py README.md --use-lib
+
+    # convert all markdown files in a directory
+    python md2html.py docs/ --out-dir site/
+
+    # add custom css
+    python md2html.py README.md --css custom.css
+
+"""
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_CSS = """
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, 'Helvetica Neue', Arial; max-width: 760px; margin: 3rem auto; line-height: 1.6; padding: 0 1rem; }
+pre { background:#f6f8fa; padding:1rem; overflow:auto; }
+code { background:#f6f8fa; padding:0.15rem 0.3rem; border-radius:4px; }
+h1,h2,h3,h4 { margin-top:1.4rem; }
+blockquote { color:#555; border-left:4px solid #ddd; padding-left:1rem; margin:1rem 0; }
+ul,ol { margin:0.5rem 0 1rem 1.25rem; }
+"""
+
+# -------------------- Simple markdown parser --------------------
+# This is intentionally small: it handles common constructs but is NOT a
+# full CommonMark parser. Use the markdown package for full fidelity.
+
+_heading_re = re.compile(r'^(#{1,6})\s+(.*)$')
+_hr_re = re.compile(r'^(\*{3,}|-{3,}|_{3,})$')
+_codeblock_start_re = re.compile(r'^```(.*)$')
+_list_item_re = re.compile(r'^(\s*)([-*+]|\d+\.)\s+(.*)$')
+_blockquote_re = re.compile(r'^(>+)\s?(.*)$')
+
+def escape_html(s: str) -> str:
+    return (s.replace('&', '&amp;')
+            .replace('<', '&lt;')
+            .replace('>', '&gt;'))
+
+def inline_transform(s: str) -> str:
+    # Strong: **text** or __text__
+    s = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', s)
+    s = re.sub(r'__(.+?)__', r'<strong>\1</strong>', s)
+    # Emphasis: *text* or _text_
+    s = re.sub(r'(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)', r'<em>\1</em>', s)
+    s = re.sub(r'_(.+?)_', r'<em>\1</em>', s)
+    # Inline code `code`
+    s = re.sub(r'`([^`]+?)`', lambda m: f"<code>{escape_html(m.group(1))}</code>", s)
+    # Links [text](url)
+    s = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', s)
+    return s
+
+
+def convert_simple_markdown(md_text: str) -> str:
+    lines = md_text.splitlines()
+    out_lines = []
+
+    in_codeblock = False
+    codeblock_lang = ''
+    codeblock_lines = []
+
+    list_stack = []  # stack of (indent_level, list_type)
+
+    para_open = False
+
+    def close_paragraph():
+        nonlocal para_open
+        if para_open:
+            out_lines.append('</p>')
+            para_open = False
+
+    def close_all_lists(curr_indent=0):
+        nonlocal list_stack
+        while list_stack and list_stack[-1][0] >= curr_indent:
+            _, lt = list_stack.pop()
+            out_lines.append(f'</{lt}>')
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if in_codeblock:
+            if _codeblock_start_re.match(line):
+                # end code block
+                in_codeblock = False
+                out_lines.append('<pre><code>')
+                out_lines.extend(escape_html(l) for l in codeblock_lines)
+                out_lines.append('</code></pre>')
+                codeblock_lines = []
+                continue
+            else:
+                codeblock_lines.append(line)
+                continue
+
+        m = _codeblock_start_re.match(line)
+        if m:
+            close_paragraph()
+            close_all_lists()
+            in_codeblock = True
+            codeblock_lang = m.group(1).strip()
+            codeblock_lines = []
+            continue
+
+        if not line.strip():
+            # blank line -> paragraph/list/code separation
+            close_paragraph()
+            close_all_lists()
+            continue
+
+        # horizontal rule
+        if _hr_re.match(line.strip()):
+            close_paragraph()
+            close_all_lists()
+            out_lines.append('<hr/>')
+            continue
+
+        # heading
+        m = _heading_re.match(line)
+        if m:
+            close_paragraph()
+            close_all_lists()
+            level = len(m.group(1))
+            text = inline_transform(m.group(2).strip())
+            out_lines.append(f'<h{level}>{text}</h{level}>')
+            continue
+
+        # blockquote
+        m = _blockquote_re.match(line)
+        if m:
+            close_paragraph()
+            close_all_lists()
+            depth = len(m.group(1))
+            text = inline_transform(m.group(2).strip())
+            # simple: wrap entire line in blockquote tags (no nesting handling)
+            out_lines.append(f'<blockquote>{text}</blockquote>')
+            continue
+
+        # list item
+        m = _list_item_re.match(line)
+        if m:
+            indent = len(m.group(1).expandtabs(4))
+            marker = m.group(2)
+            content = inline_transform(m.group(3).strip())
+            list_type = 'ul' if not marker.endswith('.') else 'ol'
+
+            if not list_stack or indent > list_stack[-1][0]:
+                # open new list
+                list_stack.append((indent, list_type))
+                out_lines.append(f'<{list_type}>')
+            else:
+                # close lists until current indent fits
+                while list_stack and indent < list_stack[-1][0]:
+                    _, lt = list_stack.pop()
+                    out_lines.append(f'</{lt}>')
+                # if same indent but different list type, close and open
+                if list_stack and list_stack[-1][1] != list_type:
+                    _, lt = list_stack.pop()
+                    out_lines.append(f'</{lt}>')
+                    list_stack.append((indent, list_type))
+                    out_lines.append(f'<{list_type}>')
+
+            out_lines.append(f'<li>{content}</li>')
+            continue
+
+        # normal paragraph text
+        if not para_open:
+            para_open = True
+            out_lines.append('<p>')
+        out_lines.append(inline_transform(line.strip()))
+
+    # finish up
+    if in_codeblock:
+        # unclosed code block: flush what we have
+        out_lines.append('<pre><code>')
+        out_lines.extend(escape_html(l) for l in codeblock_lines)
+        out_lines.append('</code></pre>')
+
+    close_paragraph()
+    close_all_lists(0)
+
+    return "\n".join(out_lines)
+
+# -------------------- HTML template & file helpers --------------------
+
+def make_html_page(title: str, body_html: str, css: str | None = None) -> str:
+    if css is None:
+        css = DEFAULT_CSS
+    return f"""
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{escape_html(title)}</title>
+<style>
+{css}
+</style>
+</head>
+<body>
+<main>
+{body_html}
+</main>
+</body>
+</html>
+"""
+
+
+def write_output(html: str, out_path: Path):
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html, encoding='utf-8')
+    print(f'Wrote: {out_path}')
+
+# -------------------- Optional markdown lib mode --------------------
+try:
+    import markdown as _markdown_lib  # type: ignore
+except Exception:
+    _markdown_lib = None
+
+
+def convert_with_markdown_lib(md_text: str) -> str:
+    if _markdown_lib is None:
+        raise RuntimeError('markdown package is not installed. run: pip install markdown')
+    return _markdown_lib.markdown(md_text, extensions=['fenced_code', 'tables', 'codehilite'])
+
+# -------------------- CLI --------------------
+
+def process_file(in_path: Path, out_path: Path, use_lib: bool, css_text: str | None):
+    md_text = in_path.read_text(encoding='utf-8')
+    if use_lib:
+        body = convert_with_markdown_lib(md_text)
+    else:
+        body = convert_simple_markdown(md_text)
+    html = make_html_page(title=in_path.stem, body_html=body, css=css_text)
+    write_output(html, out_path)
+
+
+def gather_files(input_path: Path):
+    if input_path.is_dir():
+        return list(input_path.glob('**/*.md'))
+    elif input_path.is_file() and input_path.suffix.lower() == '.md':
+        return [input_path]
+    else:
+        raise FileNotFoundError(f'No markdown files found at: {input_path}')
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description='Convert Markdown (.md) files to standalone HTML')
+    p.add_argument('input', help='Path to a .md file or a directory containing .md files')
+    p.add_argument('--out-dir', help='Output directory (defaults to same folder as input)', default=None)
+    p.add_argument('--use-lib', help='Use the "markdown" Python package for conversion', action='store_true')
+    p.add_argument('--css', help='Path to custom CSS file to include in HTML', default=None)
+    args = p.parse_args(argv)
+
+    in_path = Path(args.input)
+    out_dir = Path(args.out_dir) if args.out_dir else None
+
+    css_text = None
+    if args.css:
+        css_text = Path(args.css).read_text(encoding='utf-8')
+
+    files = gather_files(in_path)
+    if not files:
+        print('No markdown files found, exiting.')
+        return
+
+    for md in files:
+        # determine out path
+        if out_dir:
+            rel = md.relative_to(in_path) if in_path.is_dir() else md.name
+            if isinstance(rel, Path):
+                out_path = out_dir / rel.parent / (md.stem + '.html')
+            else:
+                out_path = out_dir / (md.stem + '.html')
+        else:
+            out_path = md.with_suffix('.html')
+
+        try:
+            process_file(md, out_path, use_lib=args.use_lib, css_text=css_text)
+        except Exception as e:
+            print(f'Error processing {md}: {e}', file=sys.stderr)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### 🚀 What does this PR do?
- Adds a new beginner-friendly Python mini project: `venkateeshh-markdown-to-html-convertor`.  
- Implements a Markdown to HTML Converter that takes `.md` files and converts them into standalone `.html` files with optional CSS styling.  

### 📝 Issue Reference:
Fixes issue: # (Mention the issue number, if applicable)  

### 📁 Project Folder Created:
- `src/venkateeshh-markdown-to-html-convertor/`  

### 🧩 Project Description:
- This project demonstrates how to parse and transform Markdown text into valid HTML using Python.  
- It includes a **lightweight built-in Markdown parser** and optional support for the `markdown` package for extended features.  
- The tool is beginner-friendly, showcasing string manipulation, regex, file handling, and command-line arguments.  
- **Motivation**: Markdown is widely used in README files and documentation, and this project helps beginners understand how Markdown parsing works under the hood.  

### 🔍 Checklist:
Before submitting this PR, I have:
- [x] Created a new folder in `src/` using the format `venkateeshh-md2html-converter`.  
- [x] Added all necessary `.py` files for the project.  
- [x] Included a `README.md` with project description and run instructions.  
- [x] (Optional) Included `requirements.txt` if the project uses external packages.  
- [x] Tested the project locally and ensured it runs as expected.  

### 💻 Project Details:
- **Language Used**: Python  
- **External Dependencies**: Optional → `markdown` (install with `pip install markdown`)  
- **How to Run**:  
  ```bash
  python app.py README.md  
  # or with full markdown library  
  python app.py README.md --use-lib  
